### PR TITLE
Remove legacy stdlib function is_bool

### DIFF
--- a/manifests/defaults.pp
+++ b/manifests/defaults.pp
@@ -1,7 +1,7 @@
 # ex: syntax=puppet si ts=4 sw=4 et
 
 class bind::defaults (
-    $supported              = undef,
+    Boolean $supported      = undef,
     $chroot_supported       = undef,
     $confdir                = undef,
     $namedconf              = undef,
@@ -25,9 +25,6 @@ class bind::defaults (
     $chroot_class           = undef,
     $chroot_dir             = undef,
 ) {
-    unless is_bool($supported) {
-        fail('Please ensure that the dependencies of the bind module are installed and working correctly')
-    }
     unless $supported {
         fail('Platform is not supported')
     }

--- a/metadata.json
+++ b/metadata.json
@@ -7,28 +7,53 @@
   "source": "git://github.com/inkblot/puppet-bind.git",
   "project_page": "https://github.com/inkblot/puppet-bind",
   "issues_url": "https://github.com/inkblot/puppet-bind/issues",
-  "tags": [ "bind", "dns", "dnssec", "nsupdate" ],
+  "tags": [
+    "bind",
+    "dns",
+    "dnssec",
+    "nsupdate"
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Debian",
-      "operatingsystemrelease": [ "7", "8", "9"]
+      "operatingsystemrelease": [
+        "7",
+        "8",
+        "9"
+      ]
     },
     {
       "operatingsystem": "Ubuntu",
-      "operatingsystemrelease": [ "12.04", "14.04", "16.04" ]
+      "operatingsystemrelease": [
+        "12.04",
+        "14.04",
+        "16.04"
+      ]
     },
     {
       "operatingsystem": "CentOS",
-      "operatingsystemrelease": [ "6", "7"]
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
     },
     {
       "operatingsystem": "RedHat",
-      "operatingsystemrelease": [ "6", "7" ]
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
     }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.15.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">= 2.2.1" }
+    {
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.15.0 < 10.0.0"
+    },
+    {
+      "name": "puppetlabs/concat",
+      "version_requirement": ">= 2.2.1 < 10.0.0"
+    }
   ],
   "data_provider": "hiera"
 }


### PR DESCRIPTION
This function has been deprecated in stdlib 9.x and up